### PR TITLE
fix: convert string to bigint in source lists

### DIFF
--- a/src/services/quotes/source-lists/api-source-list.ts
+++ b/src/services/quotes/source-lists/api-source-list.ts
@@ -1,9 +1,10 @@
 import { reduceTimeout } from '@shared/timeouts';
 import { SourceId, SourceMetadata } from '../types';
-import { IQuoteSourceList, SourceListRequest, SourceListResponse } from './types';
+import { IQuoteSourceList, SourceListRequest, SourceListResponse, StringifiedSourceListResponse } from './types';
 import { IFetchService } from '@services/fetch/types';
 import { PartialOnly } from '@utility-types';
 import { SourceWithConfigId } from '../source-registry';
+import { bigintify } from './utils';
 
 export type APISourceListRequest = PartialOnly<SourceListRequest, 'external'>;
 type SingleSourceListRequest = PartialOnly<APISourceListRequest, 'sources'> & { sourceId: SourceId };
@@ -45,6 +46,7 @@ export class APISourceList implements IQuoteSourceList {
       }),
       timeout: request.quoteTimeout,
     });
-    return response.json();
+    const quote: StringifiedSourceListResponse = await response.json();
+    return bigintify(quote);
   }
 }

--- a/src/services/quotes/source-lists/batch-api-source-list.ts
+++ b/src/services/quotes/source-lists/batch-api-source-list.ts
@@ -1,8 +1,9 @@
 import { reduceTimeout } from '@shared/timeouts';
 import { SourceId, SourceMetadata } from '../types';
-import { IQuoteSourceList, SourceListRequest, SourceListResponse } from './types';
+import { IQuoteSourceList, SourceListRequest, SourceListResponse, StringifiedSourceListResponse } from './types';
 import { IFetchService } from '@services/fetch/types';
 import { PartialOnly } from '@utility-types';
+import { bigintify } from './utils';
 
 export type BatchAPISourceListRequest = PartialOnly<SourceListRequest, 'external'>;
 export type URIGenerator = (request: BatchAPISourceListRequest) => string;
@@ -38,7 +39,7 @@ export class BatchAPISourceList implements IQuoteSourceList {
       }),
       timeout: request.quoteTimeout,
     });
-    const result: Promise<Record<SourceId, SourceListResponse>> = response.then((result) => result.json());
-    return Object.fromEntries(request.sources.map((sourceId) => [sourceId, result.then((responses) => responses[sourceId])]));
+    const result: Promise<Record<SourceId, StringifiedSourceListResponse>> = response.then((result) => result.json());
+    return Object.fromEntries(request.sources.map((sourceId) => [sourceId, result.then((responses) => bigintify(responses[sourceId]))]));
   }
 }

--- a/src/services/quotes/source-lists/types.ts
+++ b/src/services/quotes/source-lists/types.ts
@@ -34,3 +34,6 @@ export type SourceListResponse = {
   source: { id: SourceId; allowanceTarget: Address; name: string; logoURI: string; customData?: Record<string, any> };
   tx: QuoteTransaction;
 };
+
+export type StringifiedSourceListResponse = StringifyBigInt<SourceListResponse>;
+type StringifyBigInt<T extends any> = T extends object ? { [K in keyof T]: bigint extends T[K] ? `${bigint}` : StringifyBigInt<T[K]> } : T;

--- a/src/services/quotes/source-lists/utils.ts
+++ b/src/services/quotes/source-lists/utils.ts
@@ -1,0 +1,25 @@
+import { BigIntish } from '@types';
+import { SourceListResponse, StringifiedSourceListResponse } from './types';
+
+export function bigintify(quote: StringifiedSourceListResponse): SourceListResponse {
+  return {
+    ...quote,
+    sellAmount: BigInt(quote.sellAmount),
+    buyAmount: BigInt(quote.buyAmount),
+    maxSellAmount: BigInt(quote.maxSellAmount),
+    minBuyAmount: BigInt(quote.minBuyAmount),
+    estimatedGas: toBigInt(quote.estimatedGas),
+    tx: {
+      ...quote.tx,
+      value: toBigInt(quote.tx.value),
+      maxPriorityFeePerGas: toBigInt(quote.tx.maxPriorityFeePerGas),
+      maxFeePerGas: toBigInt(quote.tx.maxFeePerGas),
+      gasPrice: toBigInt(quote.tx.gasPrice),
+      gasLimit: toBigInt(quote.tx.gasLimit),
+    },
+  };
+}
+
+function toBigInt(value: BigIntish | undefined) {
+  return value === undefined ? undefined : BigInt(value);
+}

--- a/src/services/quotes/types.ts
+++ b/src/services/quotes/types.ts
@@ -5,7 +5,6 @@ import { Either } from '@utility-types';
 import { CompareQuotesBy, CompareQuotesUsing } from './quote-compare';
 import { QuoteSourceMetadata, QuoteSourceSupport } from './quote-sources/types';
 import { LocalSourceConfig, SourceConfig } from './source-registry';
-import { Transaction } from 'viem';
 
 export type GlobalQuoteSourceConfig = {
   referrer?: {

--- a/src/services/quotes/types.ts
+++ b/src/services/quotes/types.ts
@@ -5,6 +5,7 @@ import { Either } from '@utility-types';
 import { CompareQuotesBy, CompareQuotesUsing } from './quote-compare';
 import { QuoteSourceMetadata, QuoteSourceSupport } from './quote-sources/types';
 import { LocalSourceConfig, SourceConfig } from './source-registry';
+import { Transaction } from 'viem';
 
 export type GlobalQuoteSourceConfig = {
   referrer?: {


### PR DESCRIPTION
We have recently made a change where we converted source list responses to bigint, instead of string. The thing is that typescript doesn't alert us that `APISourceList` and `BatchAPISourceList` were actually returning strings, since rest APIs can't handle bigints

So we are now converting those two responses to bigint, so everything works as expected