### PR TITLE
fix: always return calculated values in cache

### DIFF
--- a/src/shared/concurrent-lru-cache.ts
+++ b/src/shared/concurrent-lru-cache.ts
@@ -176,7 +176,7 @@ export class ConcurrentLRUCacheWithContext<Context, Key extends ValidKey, Value>
     // Check all values again
     for (const key of notInCache) {
       // Check if we could calculate it
-      const calculatedValue = calculated[key];
+      const calculatedValue: Value | undefined = calculated[key];
       if (calculatedValue !== undefined) {
         result[key] = calculatedValue;
       } else {

--- a/src/shared/concurrent-lru-cache.ts
+++ b/src/shared/concurrent-lru-cache.ts
@@ -76,7 +76,7 @@ export class ConcurrentLRUCacheWithContext<Context, Key extends ValidKey, Value>
   private readonly calculate: (context: Context, keys: Key[]) => Promise<Record<Key, Value>>;
   private readonly storableKeyMapper: ToStorableKey<Key>;
   private readonly expirationConfig: ExpirationConfigOptions;
-  private readonly beingCalculated: Map<StorableKey, Promise<any>> = new Map();
+  private readonly beingCalculated: Map<StorableKey, Promise<Value | undefined>> = new Map();
   private readonly cache: LRUCache<string, { lastUpdated: Timestamp; value: Value }>;
 
   constructor({ calculate, config }: CacheConstructorParams<Context, Key, Value>) {
@@ -152,17 +152,22 @@ export class ConcurrentLRUCacheWithContext<Context, Key extends ValidKey, Value>
             const value = result[key];
             if (value !== undefined) {
               this.cache.set(storableKey, { lastUpdated: Date.now(), value });
+              return value;
             }
+            return undefined;
           })
-          .catch(() => {})
+          .catch(() => undefined)
           .finally(() => this.beingCalculated.delete(storableKey));
         this.beingCalculated.set(storableKey, promise);
       }
     }
 
     // Wait for all calculations
-    const calculationPromises = notInCache.map((key) => this.beingCalculated.get(storableKeys[key]));
-    await Promise.all(calculationPromises);
+    const calculationPromises = notInCache.map<Promise<[Key, Value | undefined]>>(async (key) => [
+      key,
+      await this.beingCalculated.get(storableKeys[key]),
+    ]);
+    const calculated = Object.fromEntries(await Promise.all(calculationPromises)) as Record<Key, Value | undefined>;
 
     const nowAgain = Date.now();
     const useCachedValueIfCalculationFailed = ({ lastUpdated }: { lastUpdated: Timestamp }) =>
@@ -170,15 +175,22 @@ export class ConcurrentLRUCacheWithContext<Context, Key extends ValidKey, Value>
 
     // Check all values again
     for (const key of notInCache) {
-      const storableKey = storableKeys[key];
-      const valueInCache = this.cache.get(storableKey);
-      if (valueInCache) {
-        if (useCachedValueIfCalculationFailed(valueInCache)) {
-          // If can use it, then add it to result
-          result[key] = valueInCache.value;
-        } else {
-          // If not, then delete the value
-          this.cache.delete(storableKey);
+      // Check if we could calculate it
+      const calculatedValue = calculated[key];
+      if (calculatedValue !== undefined) {
+        result[key] = calculatedValue;
+      } else {
+        // If we couldn't calculate it, check if we had an old value stored in the cache we can still use
+        const storableKey = storableKeys[key];
+        const valueInCache = this.cache.get(storableKey);
+        if (valueInCache) {
+          if (useCachedValueIfCalculationFailed(valueInCache)) {
+            // If can use it, then add it to result
+            result[key] = valueInCache.value;
+          } else {
+            // If not, then delete the value
+            this.cache.delete(storableKey);
+          }
         }
       }
     }


### PR DESCRIPTION
We had a problem in our cache that happened in a "kind of corner case". For example, if the cache was configured to have a max size of 50 entries, but we asked for the values of 100 keys, we would get a response for 50 keys, not the 100.

This was because we would store calculated values on the cache, and they build the result by also reading them from the cache. So, if the cache has a max size of 50, then we wouldn't have a value for the other 50 keys

The fix is quite simple though. The `Promise` we were using to determine if a value was being calculated would also return the calculated value (or undefined if we failed to calculate a value for it). Then, we will build the result based on those returned values, not the cache. 

We will continue to store values on the cache though, so we can avoid future re-calculations