### PR TITLE
feat: added getSupportedStrategies endpoint to EarnService

### DIFF
--- a/src/sdk/builders/earn-builder.ts
+++ b/src/sdk/builders/earn-builder.ts
@@ -1,15 +1,28 @@
 import { IAllowanceService } from '@services/allowances';
 import { EarnService } from '@services/earn/earn-service';
+import { IFetchService } from '@services/fetch';
 import { IPermit2Service } from '@services/permit2';
 import { IProviderService } from '@services/providers';
 import { IQuoteService } from '@services/quotes';
 
+export type BuildEarnParams = { customAPIUrl?: string };
 type Dependencies = {
   permit2Service: IPermit2Service;
   quoteService: IQuoteService;
   providerService: IProviderService;
   allowanceService: IAllowanceService;
+  fetchService: IFetchService;
 };
-export function buildEarnService({ permit2Service, quoteService, providerService, allowanceService }: Dependencies) {
-  return new EarnService(permit2Service, quoteService, providerService, allowanceService);
+export function buildEarnService(
+  params: BuildEarnParams | undefined,
+  { permit2Service, quoteService, providerService, allowanceService, fetchService }: Dependencies
+) {
+  return new EarnService(
+    params?.customAPIUrl ?? 'https://api.balmy.xyz',
+    permit2Service,
+    quoteService,
+    providerService,
+    allowanceService,
+    fetchService
+  );
 }

--- a/src/sdk/sdk-builder.ts
+++ b/src/sdk/sdk-builder.ts
@@ -11,7 +11,7 @@ import { BuildPriceParams, buildPriceService } from './builders/price-builder';
 import { buildPermit2Service } from './builders/permit2-builder';
 import { BuildDCAParams, buildDCAService } from './builders/dca-builder';
 import { BuildBlocksParams, buildBlocksService } from './builders/blocks-builder';
-import { buildEarnService } from './builders/earn-builder';
+import { BuildEarnParams, buildEarnService } from './builders/earn-builder';
 
 export function buildSDK<Params extends BuildParams = {}>(
   params?: Params
@@ -28,7 +28,7 @@ export function buildSDK<Params extends BuildParams = {}>(
   const quoteService = buildQuoteService(params?.quotes, providerService, fetchService, gasService as any, metadataService as any, priceService);
   const permit2Service = buildPermit2Service(quoteService, providerService, gasService as any);
   const dcaService = buildDCAService(params?.dca, { providerService, permit2Service, quoteService, fetchService, priceService });
-  const earnService = buildEarnService({ permit2Service, quoteService, providerService, allowanceService });
+  const earnService = buildEarnService(params?.earn, { permit2Service, quoteService, providerService, allowanceService, fetchService });
 
   return {
     providerService,
@@ -54,6 +54,7 @@ export type BuildParams = {
   allowances?: BuildAllowanceParams;
   gas?: BuildGasParams;
   dca?: BuildDCAParams;
+  earn?: BuildEarnParams;
   metadata?: BuildMetadataParams;
   price?: BuildPriceParams;
   quotes?: BuildQuoteParams;

--- a/src/services/earn/earn-service.ts
+++ b/src/services/earn/earn-service.ts
@@ -4,8 +4,12 @@ import {
   EarnActionSwapConfig,
   EarnPermission,
   EarnPermissionPermit,
+  Guardian,
+  GuardianId,
   IEarnService,
   IncreaseEarnPositionParams,
+  Strategy,
+  Token,
   WithdrawEarnPositionParams,
 } from './types';
 import { COMPANION_SWAPPER_CONTRACT, EARN_STRATEGY_REGISTRY, EARN_VAULT, EARN_VAULT_COMPANION } from './config';
@@ -22,14 +26,31 @@ import { IProviderService } from '@services/providers';
 import { MULTICALL_CONTRACT } from '@services/providers/utils';
 import { IAllowanceService } from '@services/allowances';
 import { PERMIT2_CONTRACT } from '@services/permit2/utils/config';
+import qs from 'qs';
+import { IFetchService } from '@services/fetch';
 
 export class EarnService implements IEarnService {
   constructor(
+    private readonly apiUrl: string,
     private readonly permit2Service: IPermit2Service,
     private readonly quoteService: IQuoteService,
     private readonly providerService: IProviderService,
-    private readonly allowanceService: IAllowanceService
+    private readonly allowanceService: IAllowanceService,
+    private readonly fetchService: IFetchService
   ) {}
+
+  async getSupportedStrategies(args?: { chains?: ChainId[]; config?: { timeout: TimeString } }) {
+    const params = qs.stringify({ chains: args?.chains }, { arrayFormat: 'comma', skipNulls: true });
+    const url = `${this.apiUrl}/v1/earn/strategies/supported?${params}`;
+    const response = await this.fetchService.fetch(url, { timeout: args?.config?.timeout });
+    const body: SupportedStrategiesResponse = await response.json();
+    const result: Record<ChainId, Strategy[]> = {};
+    Object.entries(body.strategiesByNetwork).forEach(([stringChainId, { strategies }]) => {
+      const chainId = Number(stringChainId) as ChainId;
+      result[chainId] = strategies;
+    });
+    return result;
+  }
 
   preparePermitData(args: SinglePermitParams): Promise<PermitData> {
     return this.permit2Service.preparePermitData({ ...args, spender: EARN_VAULT_COMPANION.address(args.chainId) });
@@ -579,3 +600,13 @@ async function buildCompanionMulticall({ chainId, calls, value }: { chainId: Cha
   });
   return { to: EARN_VAULT_COMPANION.address(chainId), data, value };
 }
+
+type SupportedStrategiesResponse = {
+  strategiesByNetwork: Record<ChainId, StrategiesResponse>;
+  guardians: Record<GuardianId, Guardian>;
+};
+
+type StrategiesResponse = {
+  strategies: Strategy[];
+  tokens: Record<TokenAddress, Token>;
+};

--- a/src/services/earn/earn-service.ts
+++ b/src/services/earn/earn-service.ts
@@ -51,10 +51,11 @@ export class EarnService implements IEarnService {
     const result: Record<ChainId, Strategy[]> = {};
     Object.entries(body.strategiesByNetwork).forEach(([stringChainId, { strategies, tokens }]) => {
       const chainId = Number(stringChainId) as ChainId;
-      result[chainId] = strategies.map(({ farm: { rewards, asset, ...restFarm }, guardian, ...strategyResponse }) => {
+      result[chainId] = strategies.map(({ farm: { rewards, asset, ...restFarm }, guardian, depositTokens, ...strategyResponse }) => {
         const strategy: Strategy = {
           ...{
             ...strategyResponse,
+            depositTokens: depositTokens.map((token) => tokens[token]),
             farm: {
               ...restFarm,
               asset: tokens[asset],
@@ -63,8 +64,8 @@ export class EarnService implements IEarnService {
         };
         if (rewards) {
           strategy.farm.rewards = {
-            tokens: rewards ? rewards?.tokens.map((token) => tokens[token]) : [],
-            apy: rewards?.apy ?? 0,
+            tokens: rewards.tokens.map((token) => tokens[token]),
+            apy: rewards.apy,
           };
         }
         if (guardian) {

--- a/src/services/earn/types.ts
+++ b/src/services/earn/types.ts
@@ -66,14 +66,16 @@ export type AddFundsEarn = { swapConfig?: EarnActionSwapConfig } & (
 
 export type Strategy = {
   id: StrategyId;
+  chainId: ChainId;
+  depositTokens: TokenAddress[];
   farm: StrategyFarm;
   guardian?: StrategyGuardian;
+  tos?: string;
 };
 
 type StrategyFarm = {
   id: FarmId;
   name: string;
-  chainId: ChainId;
   asset: Token;
   rewards?: { tokens: Token[]; apy: number };
   tvl: number;
@@ -81,7 +83,7 @@ type StrategyFarm = {
   apy: number;
 };
 
-type StrategyGuardian = {
+export type StrategyGuardian = {
   id: GuardianId;
   name: string;
   description: string;
@@ -110,9 +112,9 @@ type GuardianFee = {
 type StrategyIdNumber = number;
 type StrategyRegistryAddress = Lowercase<Address>;
 export type StrategyId = `${ChainId}-${StrategyRegistryAddress}-${StrategyIdNumber}`;
-type FarmId = string;
+export type FarmId = `${ChainId}-${Lowercase<Address>}`;
 export type GuardianId = string;
-enum StrategyYieldType {
+export enum StrategyYieldType {
   LENDING = 'LENDING',
   STAKING = 'STAKING',
   AGGREAGATOR = 'AGGREGATOR',

--- a/src/services/earn/types.ts
+++ b/src/services/earn/types.ts
@@ -13,7 +13,7 @@ export type IEarnService = {
   buildCreatePositionTx(_: CreateEarnPositionParams): Promise<BuiltTransaction>;
   buildIncreasePositionTx(_: IncreaseEarnPositionParams): Promise<BuiltTransaction>;
   buildWithdrawPositionTx(_: WithdrawEarnPositionParams): Promise<BuiltTransaction>;
-  getSupportedStrategies(_?: { chains?: ChainId[]; config?: { timeout: TimeString } }): Promise<Record<ChainId, Strategy[]>>;
+  getSupportedStrategies(_?: { chains?: ChainId[]; config?: { timeout?: TimeString } }): Promise<Record<ChainId, Strategy[]>>;
 };
 
 export type CreateEarnPositionParams = {
@@ -67,7 +67,7 @@ export type AddFundsEarn = { swapConfig?: EarnActionSwapConfig } & (
 export type Strategy = {
   id: StrategyId;
   chainId: ChainId;
-  depositTokens: TokenAddress[];
+  depositTokens: Token[];
   farm: StrategyFarm;
   guardian?: StrategyGuardian;
   tos?: string;

--- a/src/services/earn/types.ts
+++ b/src/services/earn/types.ts
@@ -13,6 +13,7 @@ export type IEarnService = {
   buildCreatePositionTx(_: CreateEarnPositionParams): Promise<BuiltTransaction>;
   buildIncreasePositionTx(_: IncreaseEarnPositionParams): Promise<BuiltTransaction>;
   buildWithdrawPositionTx(_: WithdrawEarnPositionParams): Promise<BuiltTransaction>;
+  getSupportedStrategies(_?: { chains?: ChainId[]; config?: { timeout: TimeString } }): Promise<Record<ChainId, Strategy[]>>;
 };
 
 export type CreateEarnPositionParams = {
@@ -62,3 +63,57 @@ export type AddFundsEarn = { swapConfig?: EarnActionSwapConfig } & (
   | { permitData: PermitData['permitData']; signature: string }
   | { token: TokenAddress; amount: BigIntish }
 );
+
+export type Strategy = {
+  id: StrategyId;
+  farm: StrategyFarm;
+  guardian?: StrategyGuardian;
+};
+
+type StrategyFarm = {
+  id: FarmId;
+  name: string;
+  chainId: ChainId;
+  asset: Token;
+  rewards?: { tokens: Token[]; apy: number };
+  tvl: number;
+  type: StrategyYieldType;
+  apy: number;
+};
+
+type StrategyGuardian = {
+  id: GuardianId;
+  name: string;
+  description: string;
+  logo: string;
+  fees: GuardianFee[];
+};
+
+export type Guardian = {
+  name: string;
+  description: string;
+  logo: string;
+};
+
+export type Token = {
+  symbol: string;
+  name: string;
+  decimals: number;
+  price?: number;
+};
+
+type GuardianFee = {
+  type: 'deposit' | 'withdraw' | 'performance' | 'rescue';
+  percentage: number;
+};
+
+type StrategyIdNumber = number;
+type StrategyRegistryAddress = Lowercase<Address>;
+export type StrategyId = `${ChainId}-${StrategyRegistryAddress}-${StrategyIdNumber}`;
+type FarmId = string;
+export type GuardianId = string;
+enum StrategyYieldType {
+  LENDING = 'LENDING',
+  STAKING = 'STAKING',
+  AGGREAGATOR = 'AGGREGATOR',
+}


### PR DESCRIPTION
This pull request adds a new endpoint, `getSupportedStrategies`, to the `EarnService` class. This endpoint retrieves a list of supported strategies for earning rewards. The list includes information about the strategies, such as the farm, rewards, TVL, and APY. The endpoint also returns information about the guardians associated with each strategy. This new feature enhances the functionality of the `EarnService` and provides users with valuable information about available earning strategies.