### PR TITLE
Add preparePermissionData to EarnService on the SDK

### DIFF
--- a/src/shared/abis/earn-vault.ts
+++ b/src/shared/abis/earn-vault.ts
@@ -77,4 +77,11 @@ export default [
     stateMutability: 'view',
     type: 'function',
   },
+  {
+    inputs: [{ internalType: 'address', name: 'owner', type: 'address' }],
+    name: 'nextNonce',
+    outputs: [{ internalType: 'uint256', name: 'nextNonce', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
 ] as const;


### PR DESCRIPTION
This pull request adds the `preparePermissionData` method to the `EarnService` class in the SDK. This method prepares the data required for granting permissions to an Earn NFT position. It takes in the chain ID, position ID, permissions, signer address, and signature validity period as parameters and returns the prepared permission data. This addition enhances the functionality of the SDK by allowing developers to easily manage permissions for Earn NFT positions.