### PR TITLE
refactor: update withdraw function in EarnService to handle special withdrawals

### DIFF
--- a/src/services/earn/earn-service.ts
+++ b/src/services/earn/earn-service.ts
@@ -651,15 +651,13 @@ export class EarnService implements IEarnService {
       );
     }
 
-    let balancesFromVault: Record<TokenAddress, bigint> = {};
-
     const [positionTokens, positionBalances, strategyAddress] = await this.providerService.getViemPublicClient({ chainId }).readContract({
       abi: vaultAbi,
       address: vault,
       functionName: 'position',
       args: [bigIntPositionId],
     });
-    balancesFromVault = Object.fromEntries(positionTokens.map((token, index) => [token, positionBalances[index]]));
+    const balancesFromVault = Object.fromEntries(positionTokens.map((token, index) => [token, positionBalances[index]]));
 
     // Handle swaps
     const withdrawsToConvert = withdraw.amounts

--- a/src/services/earn/earn-service.ts
+++ b/src/services/earn/earn-service.ts
@@ -1013,10 +1013,6 @@ function fulfillBalance(balances: { token: TokenAddress; amount: bigint; profit:
   }));
 }
 
-function toStrategyId(chainId: ChainId, strategyRegistry: StrategyRegistryAddress, tokenId: StrategyIdNumber) {
-  return `${chainId}-${strategyRegistry}-${tokenId}` satisfies StrategyId;
-}
-
 type GetStrategyResponse = {
   strategy: StrategyResponse & HistoricalData;
   tokens: Record<ViemAddress, Token>;

--- a/src/services/earn/types.ts
+++ b/src/services/earn/types.ts
@@ -59,7 +59,7 @@ export type WithdrawEarnPositionParams = {
   chainId: ChainId;
   positionId: PositionId;
   withdraw: {
-    amounts: { token: TokenAddress; amount: BigIntish; convertTo?: TokenAddress }[];
+    amounts: { token: TokenAddress; amount: BigIntish; convertTo?: TokenAddress; type: WithdrawType }[];
     swapConfig?: EarnActionSwapConfig;
   };
   recipient: Address;
@@ -278,3 +278,14 @@ export type EarnPermissionDataMessage = {
   nonce: bigint;
   deadline: bigint;
 };
+
+export enum WithdrawType {
+  IMMEDIATE = 'IMMEDIATE',
+  DELAYED = 'DELAYED',
+  MARKET = 'MARKET',
+}
+
+export enum SpecialWithdrawalCode {
+  WITHDRAW_ASSET_FARM_TOKEN_BY_AMOUNT = 0,
+  WITHDRAW_ASSET_FARM_TOKEN_BY_ASSET_AMOUNT = 1,
+}

--- a/src/shared/abis/earn-strategy-registry.ts
+++ b/src/shared/abis/earn-strategy-registry.ts
@@ -6,4 +6,11 @@ export default [
     stateMutability: 'view',
     type: 'function',
   },
+  {
+    inputs: [{ internalType: 'contract IEarnStrategy', name: 'strategy', type: 'address' }],
+    name: 'assignedId',
+    outputs: [{ internalType: 'StrategyId', name: 'strategyId', type: 'uint96' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
 ] as const;

--- a/src/shared/abis/earn-vault-companion.ts
+++ b/src/shared/abis/earn-vault-companion.ts
@@ -167,4 +167,68 @@ export default [
     ],
     stateMutability: 'payable',
   },
+  {
+    type: 'function',
+    name: 'specialWithdraw',
+    inputs: [
+      {
+        name: 'vault',
+        type: 'address',
+        internalType: 'contract IEarnVault',
+      },
+      {
+        name: 'positionId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: 'withdrawalCode',
+        type: 'uint256',
+        internalType: 'SpecialWithdrawalCode',
+      },
+      {
+        name: 'toWithdraw',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
+      {
+        name: 'withdrawalData',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+      {
+        name: 'recipient',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    outputs: [
+      {
+        name: 'tokens',
+        type: 'address[]',
+        internalType: 'address[]',
+      },
+      {
+        name: 'balanceChanges',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
+      {
+        name: 'actualWithdrawnTokens',
+        type: 'address[]',
+        internalType: 'address[]',
+      },
+      {
+        name: 'actualWithdrawnAmounts',
+        type: 'uint256[]',
+        internalType: 'uint256[]',
+      },
+      {
+        name: 'result',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+    ],
+    stateMutability: 'payable',
+  },
 ] as const;


### PR DESCRIPTION
This PR refactors the `withdraw` function in the `EarnService` class to handle special withdrawals. It introduces the `WithdrawType` enum with three options: `IMMEDIATE`, `DELAYED`, and `MARKET`. It also adds the `SpecialWithdrawalCode` enum with two options: `WITHDRAW_ASSET_FARM_TOKEN_BY_AMOUNT` and `WITHDRAW_ASSET_FARM_TOKEN_BY_ASSET_AMOUNT`. The `withdraw` function now checks if any token amount needs to be converted or if a farm token needs to be withdrawn. It then makes the appropriate calls to the companion contract for withdrawal. Additionally, the commit updates the `types.ts` file to include the new enums.
