### PR TITLE
refactor: stop passing chain to quote sources

### DIFF
--- a/src/services/quotes/quote-sources/0x-quote-source.ts
+++ b/src/services/quotes/quote-sources/0x-quote-source.ts
@@ -38,7 +38,7 @@ export class ZRXQuoteSource implements IQuoteSource<ZRXSupport, ZRXConfig, ZRXDa
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -48,7 +48,7 @@ export class ZRXQuoteSource implements IQuoteSource<ZRXSupport, ZRXConfig, ZRXDa
     config,
   }: QuoteParams<ZRXSupport, ZRXConfig>): Promise<SourceQuoteResponse<ZRXData>> {
     const queryParams = {
-      chainId: chain.chainId,
+      chainId,
       sellToken,
       buyToken,
       taker: takeFrom,
@@ -66,7 +66,7 @@ export class ZRXQuoteSource implements IQuoteSource<ZRXSupport, ZRXConfig, ZRXDa
 
     const response = await fetchService.fetch(url, { timeout, headers });
     if (!response.ok) {
-      failed(ZRX_METADATA, chain, sellToken, buyToken, await response.text());
+      failed(ZRX_METADATA, chainId, sellToken, buyToken, await response.text());
     }
     const {
       transaction: { data, gas, to, value },

--- a/src/services/quotes/quote-sources/1inch-quote-source.ts
+++ b/src/services/quotes/quote-sources/1inch-quote-source.ts
@@ -62,7 +62,7 @@ export class OneInchQuoteSource implements IQuoteSource<OneInchSupport, OneInchC
   private async getQuote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -84,10 +84,10 @@ export class OneInchQuoteSource implements IQuoteSource<OneInchSupport, OneInchC
       includeGas: true,
     };
     const queryString = qs.stringify(queryParams, { skipNulls: true, arrayFormat: 'comma' });
-    const url = `${getUrl(config)}/${chain.chainId}/swap?${queryString}`;
+    const url = `${getUrl(config)}/${chainId}/swap?${queryString}`;
     const response = await fetchService.fetch(url, { timeout, headers: getHeaders(config) });
     if (!response.ok) {
-      failed(ONE_INCH_METADATA, chain, sellToken, buyToken, (await response.text()) || `Failed with status ${response.status}`);
+      failed(ONE_INCH_METADATA, chainId, sellToken, buyToken, (await response.text()) || `Failed with status ${response.status}`);
     }
     const {
       dstAmount,

--- a/src/services/quotes/quote-sources/balancer-quote-source.ts
+++ b/src/services/quotes/quote-sources/balancer-quote-source.ts
@@ -37,7 +37,7 @@ export class BalancerQuoteSource extends AlwaysValidConfigAndContextSource<Balan
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -55,7 +55,7 @@ export class BalancerQuoteSource extends AlwaysValidConfigAndContextSource<Balan
     const query = {
       query: `query {
         sorGetSwapPaths( 
-          chain: ${SUPPORTED_CHAINS[chain.chainId]}
+          chain: ${SUPPORTED_CHAINS[chainId]}
           swapAmount: "${amount}"
           swapType: ${order.type == 'sell' ? 'EXACT_IN' : 'EXACT_OUT'}
           tokenIn: "${sellToken}"
@@ -82,12 +82,12 @@ export class BalancerQuoteSource extends AlwaysValidConfigAndContextSource<Balan
     });
 
     if (!quoteResponse.ok) {
-      failed(BALANCER_METADATA, chain, sellToken, buyToken, await quoteResponse.text());
+      failed(BALANCER_METADATA, chainId, sellToken, buyToken, await quoteResponse.text());
     }
     const quoteResult = await quoteResponse.json();
 
     if (!quoteResult.data.sorGetSwapPaths.callData) {
-      failed(BALANCER_METADATA, chain, sellToken, buyToken, quoteResult);
+      failed(BALANCER_METADATA, chainId, sellToken, buyToken, quoteResult);
     }
 
     const {

--- a/src/services/quotes/quote-sources/balmy-quote-source.ts
+++ b/src/services/quotes/quote-sources/balmy-quote-source.ts
@@ -44,7 +44,7 @@ export class BalmyQuoteSource extends AlwaysValidConfigAndContextSource<BalmySup
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       config: { slippagePercentage, timeout, txValidFor },
       accounts: { takeFrom, recipient },
       order,
@@ -54,7 +54,7 @@ export class BalmyQuoteSource extends AlwaysValidConfigAndContextSource<BalmySup
     config,
   }: QuoteParams<BalmySupport, BalmyConfig>): Promise<SourceQuoteResponse<BalmyData>> {
     const balmyUrl = config.url ?? 'https://api.balmy.xyz';
-    const url = `${balmyUrl}/v1/swap/networks/${chain.chainId}/quotes/balmy`;
+    const url = `${balmyUrl}/v1/swap/networks/${chainId}/quotes/balmy`;
     const stringOrder =
       order.type === 'sell' ? { type: 'sell', sellAmount: order.sellAmount.toString() } : { type: 'buy', buyAmount: order.buyAmount.toString() };
     const body = {
@@ -74,7 +74,7 @@ export class BalmyQuoteSource extends AlwaysValidConfigAndContextSource<BalmySup
       timeout,
     });
     if (!response.ok) {
-      failed(BALMY_METADATA, chain, request.sellToken, request.buyToken, await response.text());
+      failed(BALMY_METADATA, chainId, request.sellToken, request.buyToken, await response.text());
     }
     const {
       sellAmount,

--- a/src/services/quotes/quote-sources/barter-quote-source.ts
+++ b/src/services/quotes/quote-sources/barter-quote-source.ts
@@ -36,7 +36,7 @@ export class BarterQuoteSource implements IQuoteSource<BarterSupport, BarterConf
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -54,19 +54,19 @@ export class BarterQuoteSource implements IQuoteSource<BarterSupport, BarterConf
       headers['X-From'] = config.referrer.name;
     }
 
-    const responseEnv = await fetchService.fetch(`https://${config.customSubdomain}.${BARTER_NETWORKS[chain.chainId]}.barterswap.xyz/env`, {
+    const responseEnv = await fetchService.fetch(`https://${config.customSubdomain}.${BARTER_NETWORKS[chainId]}.barterswap.xyz/env`, {
       headers,
       timeout,
     });
     if (!responseEnv.ok) {
-      failed(BARTER_METADATA, chain, sellToken, buyToken, await responseEnv.text());
+      failed(BARTER_METADATA, chainId, sellToken, buyToken, await responseEnv.text());
     }
 
     const { defaultFilters, facadeAddress } = await responseEnv.json();
     const typeFilter = calculateTypeFilters({ config, defaultFilters });
 
     const responseSwapRoute = await fetchService.fetch(
-      `https://${config.customSubdomain}.${BARTER_NETWORKS[chain.chainId]}.barterswap.xyz/getSwapRoute`,
+      `https://${config.customSubdomain}.${BARTER_NETWORKS[chainId]}.barterswap.xyz/getSwapRoute`,
       {
         method: 'POST',
         body: JSON.stringify({ source, target, amount, typeFilter }),
@@ -76,7 +76,7 @@ export class BarterQuoteSource implements IQuoteSource<BarterSupport, BarterConf
     );
 
     if (!responseSwapRoute.ok) {
-      failed(BARTER_METADATA, chain, sellToken, buyToken, await responseSwapRoute.text());
+      failed(BARTER_METADATA, chainId, sellToken, buyToken, await responseSwapRoute.text());
     }
     const { outputAmount, gasEstimation } = await responseSwapRoute.json();
     const minBuyAmount = subtractPercentage(outputAmount, slippagePercentage, 'up');
@@ -96,7 +96,7 @@ export class BarterQuoteSource implements IQuoteSource<BarterSupport, BarterConf
   async buildTx({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       sellAmount,
@@ -125,14 +125,14 @@ export class BarterQuoteSource implements IQuoteSource<BarterSupport, BarterConf
       typeFilter,
     };
 
-    const responseSwap = await fetchService.fetch(`https://${config.customSubdomain}.${BARTER_NETWORKS[chain.chainId]}.barterswap.xyz/swap`, {
+    const responseSwap = await fetchService.fetch(`https://${config.customSubdomain}.${BARTER_NETWORKS[chainId]}.barterswap.xyz/swap`, {
       method: 'POST',
       body: JSON.stringify(bodySwap),
       timeout,
       headers,
     });
     if (!responseSwap.ok) {
-      failed(BARTER_METADATA, chain, sellToken, buyToken, await responseSwap.text());
+      failed(BARTER_METADATA, chainId, sellToken, buyToken, await responseSwap.text());
     }
     const resultSwap = await responseSwap.json();
     const { data, to, value } = resultSwap;

--- a/src/services/quotes/quote-sources/bebop-quote-source.ts
+++ b/src/services/quotes/quote-sources/bebop-quote-source.ts
@@ -34,7 +34,7 @@ export class BebopQuoteSource implements IQuoteSource<BebopSupport, BebopConfig,
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -60,16 +60,16 @@ export class BebopQuoteSource implements IQuoteSource<BebopSupport, BebopConfig,
       slippage: slippagePercentage,
     };
     const queryString = qs.stringify(queryParams, { skipNulls: true, arrayFormat: 'comma' });
-    const url = `https://api.bebop.xyz/router/${NETWORK_KEY[chain.chainId]}/v1/quote?${queryString}`;
+    const url = `https://api.bebop.xyz/router/${NETWORK_KEY[chainId]}/v1/quote?${queryString}`;
 
     const headers = { 'source-auth': config.apiKey };
     const response = await fetchService.fetch(url, { timeout, headers });
     if (!response.ok) {
-      failed(BEBOP_METADATA, chain, sellToken, buyToken, await response.text());
+      failed(BEBOP_METADATA, chainId, sellToken, buyToken, await response.text());
     }
     const result: BebopResult = await response.json();
     if ('error' in result) {
-      failed(BEBOP_METADATA, chain, sellToken, buyToken, result.error.message);
+      failed(BEBOP_METADATA, chainId, sellToken, buyToken, result.error.message);
     }
     const {
       sellTokens: {

--- a/src/services/quotes/quote-sources/changelly-quote-source.ts
+++ b/src/services/quotes/quote-sources/changelly-quote-source.ts
@@ -27,7 +27,7 @@ export class ChangellyQuoteSource implements IQuoteSource<ChangellySupport, Chan
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -47,12 +47,12 @@ export class ChangellyQuoteSource implements IQuoteSource<ChangellySupport, Chan
       takerAddress: config.disableValidation ? undefined : takeFrom,
     };
     const queryString = qs.stringify(queryParams, { skipNulls: true, arrayFormat: 'comma' });
-    const url = `https://dex-api.changelly.com/v1/${chain.chainId}/quote?${queryString}`;
+    const url = `https://dex-api.changelly.com/v1/${chainId}/quote?${queryString}`;
 
     const headers = { 'X-Api-Key': config.apiKey };
     const response = await fetchService.fetch(url, { timeout, headers });
     if (!response.ok) {
-      failed(CHANGELLY_METADATA, chain, sellToken, buyToken, await response.text());
+      failed(CHANGELLY_METADATA, chainId, sellToken, buyToken, await response.text());
     }
     const { amount_out_total, estimate_gas_total, calldata, to } = await response.json();
 

--- a/src/services/quotes/quote-sources/enso-quote-source.ts
+++ b/src/services/quotes/quote-sources/enso-quote-source.ts
@@ -32,7 +32,7 @@ export class EnsoQuoteSource implements IQuoteSource<EnsoSupport, EnsoConfig, En
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -52,7 +52,7 @@ export class EnsoQuoteSource implements IQuoteSource<EnsoSupport, EnsoConfig, En
       tokenOut: buyToken,
       routingStrategy: config?.routingStrategy ?? 'router',
       priceImpact: false,
-      chainId: chain.chainId,
+      chainId,
       slippage: Math.floor(slippagePercentage * 100),
       tokenInAmountToApprove: order.sellAmount.toString(),
       tokenInAmountToTransfer: order.sellAmount.toString(),
@@ -67,7 +67,7 @@ export class EnsoQuoteSource implements IQuoteSource<EnsoSupport, EnsoConfig, En
 
     const response = await fetchService.fetch(url, { timeout, headers });
     if (!response.ok) {
-      failed(ENSO_METADATA, chain, sellToken, buyToken, await response.text());
+      failed(ENSO_METADATA, chainId, sellToken, buyToken, await response.text());
     }
     const {
       amountOut,

--- a/src/services/quotes/quote-sources/kyberswap-quote-source.ts
+++ b/src/services/quotes/quote-sources/kyberswap-quote-source.ts
@@ -52,7 +52,7 @@ export class KyberswapQuoteSource extends AlwaysValidConfigAndContextSource<Kybe
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -61,7 +61,7 @@ export class KyberswapQuoteSource extends AlwaysValidConfigAndContextSource<Kybe
     },
     config,
   }: QuoteParams<KyberswapSupport>): Promise<SourceQuoteResponse<KyberswapData>> {
-    const chainKey = SUPPORTED_CHAINS[chain.chainId];
+    const chainKey = SUPPORTED_CHAINS[chainId];
     const headers = config.referrer?.name ? { 'x-client-id': config.referrer?.name } : undefined;
 
     const url =
@@ -74,7 +74,7 @@ export class KyberswapQuoteSource extends AlwaysValidConfigAndContextSource<Kybe
 
     const routeResponse = await fetchService.fetch(url, { timeout, headers });
     if (!routeResponse.ok) {
-      failed(KYBERSWAP_METADATA, chain, sellToken, buyToken, await routeResponse.text());
+      failed(KYBERSWAP_METADATA, chainId, sellToken, buyToken, await routeResponse.text());
     }
     const {
       data: { routeSummary, routerAddress },
@@ -94,7 +94,7 @@ export class KyberswapQuoteSource extends AlwaysValidConfigAndContextSource<Kybe
   async buildTx({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       sellAmount,
@@ -103,7 +103,7 @@ export class KyberswapQuoteSource extends AlwaysValidConfigAndContextSource<Kybe
     },
     config,
   }: BuildTxParams<KyberswapConfig, KyberswapData>): Promise<SourceQuoteTransaction> {
-    const chainKey = SUPPORTED_CHAINS[chain.chainId];
+    const chainKey = SUPPORTED_CHAINS[chainId];
     const headers = config.referrer?.name ? { 'x-client-id': config.referrer?.name } : undefined;
 
     const buildResponse = await fetchService.fetch(`https://aggregator-api.kyberswap.com/${chainKey}/api/v1/route/build`, {
@@ -121,14 +121,14 @@ export class KyberswapQuoteSource extends AlwaysValidConfigAndContextSource<Kybe
       }),
     });
     if (!buildResponse.ok) {
-      failed(KYBERSWAP_METADATA, chain, sellToken, buyToken, await buildResponse.text());
+      failed(KYBERSWAP_METADATA, chainId, sellToken, buyToken, await buildResponse.text());
     }
     const {
       data: { data, routerAddress },
     } = await buildResponse.json();
 
     if (!data) {
-      failed(KYBERSWAP_METADATA, chain, sellToken, buyToken, 'Failed to calculate a quote');
+      failed(KYBERSWAP_METADATA, chainId, sellToken, buyToken, 'Failed to calculate a quote');
     }
 
     const value = isSameAddress(sellToken, Addresses.NATIVE_TOKEN) ? sellAmount : 0n;

--- a/src/services/quotes/quote-sources/li-fi-quote-source.ts
+++ b/src/services/quotes/quote-sources/li-fi-quote-source.ts
@@ -54,7 +54,7 @@ export class LiFiQuoteSource extends AlwaysValidConfigAndContextSource<LiFiSuppo
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -67,8 +67,8 @@ export class LiFiQuoteSource extends AlwaysValidConfigAndContextSource<LiFiSuppo
     const mappedBuyToken = mapNativeToken(buyToken);
     let url =
       `https://li.quest/v1/quote` +
-      `?fromChain=${chain.chainId}` +
-      `&toChain=${chain.chainId}` +
+      `?fromChain=${chainId}` +
+      `&toChain=${chainId}` +
       `&fromToken=${mappedSellToken}` +
       `&toToken=${mappedBuyToken}` +
       `&fromAddress=${takeFrom}` +
@@ -86,7 +86,7 @@ export class LiFiQuoteSource extends AlwaysValidConfigAndContextSource<LiFiSuppo
     }
     const response = await fetchService.fetch(url, { timeout, headers });
     if (!response.ok) {
-      failed(LI_FI_METADATA, chain, sellToken, buyToken, await response.text());
+      failed(LI_FI_METADATA, chainId, sellToken, buyToken, await response.text());
     }
     const {
       estimate: { approvalAddress, toAmountMin, toAmount, gasCosts },

--- a/src/services/quotes/quote-sources/magpie-quote-source.ts
+++ b/src/services/quotes/quote-sources/magpie-quote-source.ts
@@ -39,7 +39,7 @@ export class MagpieQuoteSource extends AlwaysValidConfigAndContextSource<MagpieS
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -49,7 +49,7 @@ export class MagpieQuoteSource extends AlwaysValidConfigAndContextSource<MagpieS
     config,
   }: QuoteParams<MagpieSupport, MagpieConfig>): Promise<SourceQuoteResponse<MagpieData>> {
     const quoteQueryParams = {
-      network: SUPPORTED_CHAINS[chain.chainId],
+      network: SUPPORTED_CHAINS[chainId],
       fromTokenAddress: mapToken(sellToken),
       toTokenAddress: mapToken(buyToken),
       sellAmount: order.sellAmount.toString(),
@@ -61,7 +61,7 @@ export class MagpieQuoteSource extends AlwaysValidConfigAndContextSource<MagpieS
     const quoteUrl = `https://api.magpiefi.xyz/aggregator/quote?${quoteQueryString}`;
     const quoteResponse = await fetchService.fetch(quoteUrl, { timeout });
     if (!quoteResponse.ok) {
-      failed(MAGPIE_METADATA, chain, sellToken, buyToken, await quoteResponse.text());
+      failed(MAGPIE_METADATA, chainId, sellToken, buyToken, await quoteResponse.text());
     }
     const { id: quoteId, amountOut, targetAddress, fees } = await quoteResponse.json();
     const estimatedGasNum: `${number}` | undefined = fees.find((fee: { type: string; value: `${number}` }) => fee.type === 'gas')?.value;
@@ -81,7 +81,7 @@ export class MagpieQuoteSource extends AlwaysValidConfigAndContextSource<MagpieS
   async buildTx({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       config: { timeout },
@@ -98,7 +98,7 @@ export class MagpieQuoteSource extends AlwaysValidConfigAndContextSource<MagpieS
     const transactionUrl = `https://api.magpiefi.xyz/aggregator/transaction?${transactionQueryString}`;
     const transactionResponse = await fetchService.fetch(transactionUrl, { timeout });
     if (!transactionResponse.ok) {
-      failed(MAGPIE_METADATA, chain, sellToken, buyToken, await transactionResponse.text());
+      failed(MAGPIE_METADATA, chainId, sellToken, buyToken, await transactionResponse.text());
     }
     const { to, value, data } = await transactionResponse.json();
     return { to, calldata: data, value: BigInt(value) };

--- a/src/services/quotes/quote-sources/odos-quote-source.ts
+++ b/src/services/quotes/quote-sources/odos-quote-source.ts
@@ -59,7 +59,7 @@ export class OdosQuoteSource extends AlwaysValidConfigAndContextSource<OdosSuppo
   async buildTx({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       config: { timeout },
@@ -73,7 +73,7 @@ export class OdosQuoteSource extends AlwaysValidConfigAndContextSource<OdosSuppo
       timeout,
     });
     if (!assembleResponse.ok) {
-      failed(ODOS_METADATA, chain, sellToken, buyToken, await assembleResponse.text());
+      failed(ODOS_METADATA, chainId, sellToken, buyToken, await assembleResponse.text());
     }
     const {
       transaction: { data, to, value },
@@ -91,7 +91,7 @@ async function getQuote({
   simple,
   components: { fetchService },
   request: {
-    chain,
+    chainId,
     sellToken,
     buyToken,
     order,
@@ -104,7 +104,7 @@ async function getQuote({
   const checksummedBuy = checksumAndMapIfNecessary(buyToken);
   const userAddr = checksum(takeFrom);
   const quoteBody = {
-    chainId: chain.chainId,
+    chainId,
     inputTokens: [{ tokenAddress: checksummedSell, amount: order.sellAmount.toString() }],
     outputTokens: [{ tokenAddress: checksummedBuy, proportion: 1 }],
     userAddr,
@@ -125,16 +125,16 @@ async function getQuote({
       headers: { 'Content-Type': 'application/json' },
       timeout,
     }),
-    fetchService.fetch(`https://api.odos.xyz/info/router/v2/${chain.chainId}`, {
+    fetchService.fetch(`https://api.odos.xyz/info/router/v2/${chainId}`, {
       headers: { 'Content-Type': 'application/json' },
       timeout,
     }),
   ]);
   if (!quoteResponse.ok) {
-    failed(ODOS_METADATA, chain, sellToken, buyToken, await quoteResponse.text());
+    failed(ODOS_METADATA, chainId, sellToken, buyToken, await quoteResponse.text());
   }
   if (!routerResponse.ok) {
-    failed(ODOS_METADATA, chain, sellToken, buyToken, await routerResponse.text());
+    failed(ODOS_METADATA, chainId, sellToken, buyToken, await routerResponse.text());
   }
   const {
     pathId,

--- a/src/services/quotes/quote-sources/okx-dex-quote-source.ts
+++ b/src/services/quotes/quote-sources/okx-dex-quote-source.ts
@@ -4,7 +4,7 @@ import { Chains } from '@chains';
 import { IQuoteSource, QuoteParams, QuoteSourceMetadata, SourceQuoteResponse, SourceQuoteTransaction, BuildTxParams } from './types';
 import { failed } from './utils';
 import { IFetchService } from '@services/fetch';
-import { Address, Chain, TimeString } from '@types';
+import { Address, ChainId, TimeString } from '@types';
 import { Addresses, Uint } from '@shared/constants';
 import { isSameAddress } from '@shared/utils';
 
@@ -91,7 +91,7 @@ export class OKXDexQuoteSource implements IQuoteSource<OKXDexSupport, OKXDexConf
 async function calculateApprovalTarget({
   components: { fetchService },
   request: {
-    chain,
+    chainId,
     sellToken,
     buyToken,
     config: { timeout },
@@ -102,7 +102,7 @@ async function calculateApprovalTarget({
     return { data: [{ dexContractAddress: Addresses.ZERO_ADDRESS }] };
   }
   const queryParams = {
-    chainId: chain.chainId,
+    chainId,
     tokenContractAddress: sellToken,
     approveAmount: Uint.MAX_256,
   };
@@ -111,7 +111,7 @@ async function calculateApprovalTarget({
   return fetch({
     sellToken,
     buyToken,
-    chain,
+    chainId,
     path,
     timeout,
     config,
@@ -122,7 +122,7 @@ async function calculateApprovalTarget({
 async function calculateQuote({
   components: { fetchService },
   request: {
-    chain,
+    chainId,
     sellToken,
     buyToken,
     order,
@@ -132,7 +132,7 @@ async function calculateQuote({
   config,
 }: QuoteParams<OKXDexSupport, OKXDexConfig>) {
   const queryParams = {
-    chainId: chain.chainId,
+    chainId,
     amount: order.sellAmount.toString(),
     fromTokenAddress: sellToken,
     toTokenAddress: buyToken,
@@ -146,7 +146,7 @@ async function calculateQuote({
   return fetch({
     sellToken,
     buyToken,
-    chain,
+    chainId,
     path,
     timeout,
     config,
@@ -157,7 +157,7 @@ async function calculateQuote({
 async function fetch({
   sellToken,
   buyToken,
-  chain,
+  chainId,
   path,
   fetchService,
   config,
@@ -165,7 +165,7 @@ async function fetch({
 }: {
   sellToken: Address;
   buyToken: Address;
-  chain: Chain;
+  chainId: ChainId;
   path: string;
   timeout?: TimeString;
   config: OKXDexConfig;
@@ -186,7 +186,7 @@ async function fetch({
   const url = `https://www.okx.com${path}`;
   const response = await fetchService.fetch(url, { timeout, headers });
   if (!response.ok) {
-    failed(OKX_DEX_METADATA, chain, sellToken, buyToken, await response.text());
+    failed(OKX_DEX_METADATA, chainId, sellToken, buyToken, await response.text());
   }
   return response.json();
 }

--- a/src/services/quotes/quote-sources/open-ocean-quote-source.ts
+++ b/src/services/quotes/quote-sources/open-ocean-quote-source.ts
@@ -56,7 +56,7 @@ export class OpenOceanQuoteSource extends AlwaysValidConfigAndContextSource<Open
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -70,7 +70,7 @@ export class OpenOceanQuoteSource extends AlwaysValidConfigAndContextSource<Open
     const legacyGasPrice = eip1159ToLegacy(gasPriceResult);
     const gasPrice = parseFloat(formatUnits(legacyGasPrice, 9));
     const amount = formatUnits(order.sellAmount, sellTokenDataResult.decimals);
-    const { chainKey, nativeAsset } = SUPPORTED_CHAINS[chain.chainId];
+    const { chainKey, nativeAsset } = SUPPORTED_CHAINS[chainId];
     const native = nativeAsset ?? Addresses.NATIVE_TOKEN;
     const queryParams = {
       inTokenAddress: isSameAddress(sellToken, Addresses.NATIVE_TOKEN) ? native : sellToken,
@@ -90,7 +90,7 @@ export class OpenOceanQuoteSource extends AlwaysValidConfigAndContextSource<Open
     }
     const response = await fetchService.fetch(url, { timeout, headers });
     if (!response.ok) {
-      failed(OPEN_OCEAN_METADATA, chain, sellToken, buyToken, await response.text());
+      failed(OPEN_OCEAN_METADATA, chainId, sellToken, buyToken, await response.text());
     }
     const {
       data: { outAmount, estimatedGas, minOutAmount, to, value, data },

--- a/src/services/quotes/quote-sources/paraswap-quote-source.ts
+++ b/src/services/quotes/quote-sources/paraswap-quote-source.ts
@@ -35,7 +35,7 @@ export class ParaswapQuoteSource extends AlwaysValidConfigAndContextSource<Paras
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -50,7 +50,7 @@ export class ParaswapQuoteSource extends AlwaysValidConfigAndContextSource<Paras
       buyToken: { decimals: destDecimals },
     } = await external.tokenData.request();
     const queryParams = {
-      network: chain.chainId,
+      network: chainId,
       srcToken: sellToken,
       destToken: buyToken,
       amount: order.type === 'sell' ? order.sellAmount : order.buyAmount,
@@ -72,7 +72,7 @@ export class ParaswapQuoteSource extends AlwaysValidConfigAndContextSource<Paras
     const url = `https://api.paraswap.io/swap?${queryString}`;
     const response = await fetchService.fetch(url, { timeout });
     if (!response.ok) {
-      failed(PARASWAP_METADATA, chain, sellToken, buyToken, await response.text());
+      failed(PARASWAP_METADATA, chainId, sellToken, buyToken, await response.text());
     }
     const {
       priceRoute,

--- a/src/services/quotes/quote-sources/portals-fi-quote-source.ts
+++ b/src/services/quotes/quote-sources/portals-fi-quote-source.ts
@@ -1,7 +1,7 @@
 import qs from 'qs';
 import { Addresses } from '@shared/constants';
 import { isSameAddress } from '@shared/utils';
-import { Chain, ChainId, TokenAddress } from '@types';
+import { ChainId, TokenAddress } from '@types';
 import { calculateAllowanceTarget, failed } from './utils';
 import { IQuoteSource, QuoteParams, QuoteSourceMetadata, SourceQuoteResponse, SourceQuoteTransaction, BuildTxParams } from './types';
 import { Chains } from '@chains';
@@ -37,7 +37,7 @@ export class PortalsFiQuoteSource implements IQuoteSource<PortalsFiSupport, Port
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -46,8 +46,8 @@ export class PortalsFiQuoteSource implements IQuoteSource<PortalsFiSupport, Port
     },
     config,
   }: QuoteParams<PortalsFiSupport, PortalsFiConfig>): Promise<SourceQuoteResponse<PortalsFiData>> {
-    const mappedSellToken = mapToken(chain, sellToken);
-    const mappedBuyToken = mapToken(chain, buyToken);
+    const mappedSellToken = mapToken(chainId, sellToken);
+    const mappedBuyToken = mapToken(chainId, buyToken);
     const queryParams = {
       sender: takeFrom,
       inputToken: mappedSellToken,
@@ -66,7 +66,7 @@ export class PortalsFiQuoteSource implements IQuoteSource<PortalsFiSupport, Port
       headers: { Authorization: key },
     });
     if (!response.ok) {
-      failed(PORTALS_FI_METADATA, chain, sellToken, buyToken, await response.text());
+      failed(PORTALS_FI_METADATA, chainId, sellToken, buyToken, await response.text());
     }
     const {
       context: { outputAmount, minOutputAmount, value },
@@ -104,8 +104,8 @@ export class PortalsFiQuoteSource implements IQuoteSource<PortalsFiSupport, Port
   }
 }
 
-function mapToken(chain: Chain, address: TokenAddress) {
-  const chainKey = PORTALS_FI_CHAIN_ID_TO_KEY[chain.chainId];
+function mapToken(chainId: ChainId, address: TokenAddress) {
+  const chainKey = PORTALS_FI_CHAIN_ID_TO_KEY[chainId];
   const mapped = isSameAddress(address, Addresses.NATIVE_TOKEN) ? Addresses.ZERO_ADDRESS : address;
   return `${chainKey}:${mapped}`;
 }

--- a/src/services/quotes/quote-sources/rango-quote-source.ts
+++ b/src/services/quotes/quote-sources/rango-quote-source.ts
@@ -51,7 +51,7 @@ export class RangoQuoteSource implements IQuoteSource<RangoSupport, RangoConfig,
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -62,7 +62,7 @@ export class RangoQuoteSource implements IQuoteSource<RangoSupport, RangoConfig,
     config,
   }: QuoteParams<RangoSupport, RangoConfig>): Promise<SourceQuoteResponse<RangoData>> {
     const { sellToken: sellTokenDataResult, buyToken: buyTokenDataResult } = await tokenData.request();
-    const chainKey = SUPPORTED_CHAINS[chain.chainId];
+    const chainKey = SUPPORTED_CHAINS[chainId];
     const queryParams = {
       apiKey: config.apiKey,
       from: mapToChainId(chainKey, sellToken, sellTokenDataResult),
@@ -79,7 +79,7 @@ export class RangoQuoteSource implements IQuoteSource<RangoSupport, RangoConfig,
 
     const response = await fetchService.fetch(url, { timeout });
     if (!response.ok) {
-      failed(RANGO_METADATA, chain, sellToken, buyToken, await response.text());
+      failed(RANGO_METADATA, chainId, sellToken, buyToken, await response.text());
     }
     const {
       requestId,

--- a/src/services/quotes/quote-sources/sovryn-quote-source.ts
+++ b/src/services/quotes/quote-sources/sovryn-quote-source.ts
@@ -28,7 +28,7 @@ export class SovrynQuoteSource extends AlwaysValidConfigAndContextSource<SovrynS
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       config: { slippagePercentage, timeout, txValidFor },
       accounts: { takeFrom },
       order,
@@ -38,7 +38,7 @@ export class SovrynQuoteSource extends AlwaysValidConfigAndContextSource<SovrynS
     config,
   }: QuoteParams<SovrynSupport, SovrynConfig>): Promise<SourceQuoteResponse<SovrynData>> {
     const balmyUrl = config.url ?? 'https://api.balmy.xyz';
-    const url = `${balmyUrl}/v1/swap/networks/${chain.chainId}/quotes/sovryn`;
+    const url = `${balmyUrl}/v1/swap/networks/${chainId}/quotes/sovryn`;
     const body = {
       ...request,
       order: { type: 'sell', sellAmount: order.sellAmount.toString() },
@@ -55,7 +55,7 @@ export class SovrynQuoteSource extends AlwaysValidConfigAndContextSource<SovrynS
       timeout,
     });
     if (!response.ok) {
-      failed(SOVRYN_METADATA, chain, request.sellToken, request.buyToken, await response.text());
+      failed(SOVRYN_METADATA, chainId, request.sellToken, request.buyToken, await response.text());
     }
     const {
       sellAmount,

--- a/src/services/quotes/quote-sources/squid-quote-source.ts
+++ b/src/services/quotes/quote-sources/squid-quote-source.ts
@@ -40,7 +40,7 @@ export class SquidQuoteSource implements IQuoteSource<SquidSupport, SquidConfig,
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -50,8 +50,8 @@ export class SquidQuoteSource implements IQuoteSource<SquidSupport, SquidConfig,
     config,
   }: QuoteParams<SquidSupport, SquidConfig>): Promise<SourceQuoteResponse<SquidData>> {
     const params = {
-      fromChain: `${chain.chainId}`,
-      toChain: `${chain.chainId}`,
+      fromChain: `${chainId}`,
+      toChain: `${chainId}`,
       fromToken: sellToken,
       toToken: buyToken,
       fromAmount: order.sellAmount.toString(),
@@ -70,7 +70,7 @@ export class SquidQuoteSource implements IQuoteSource<SquidSupport, SquidConfig,
       headers,
     });
     if (!response.ok) {
-      failed(SQUID_METADATA, chain, sellToken, buyToken, await response.text());
+      failed(SQUID_METADATA, chainId, sellToken, buyToken, await response.text());
     }
 
     const {

--- a/src/services/quotes/quote-sources/types.ts
+++ b/src/services/quotes/quote-sources/types.ts
@@ -1,7 +1,7 @@
 import { IFetchService } from '@services/fetch/types';
 import { GasPrice } from '@services/gas/types';
 import { GlobalQuoteSourceConfig } from '@services/quotes/types';
-import { Address, Chain, ChainId, TimeString, TokenAddress } from '@types';
+import { Address, ChainId, TimeString, TokenAddress } from '@types';
 import { BaseTokenMetadata } from '@services/metadata/types';
 import { IProviderService } from '@services/providers';
 import { ITriggerablePromise } from '@shared/triggerable-promise';
@@ -27,7 +27,7 @@ export type BuildTxParams<
 };
 
 export type SourceQuoteBuildTxRequest<CustomQuoteSourceData extends Record<string, any> = Record<string, any>> = {
-  chain: Chain;
+  chainId: ChainId;
   sellToken: TokenAddress;
   buyToken: TokenAddress;
   type: 'sell' | 'buy';
@@ -64,7 +64,7 @@ export type BuyOrder = { type: 'buy'; buyAmount: bigint };
 type BaseOrder = SellOrder | BuyOrder;
 type BaseSwapAccounts = { takeFrom: Address };
 type BaseSwapQuoteRequest<Order extends BaseOrder, Accounts extends BaseSwapAccounts> = {
-  chain: Chain;
+  chainId: ChainId;
   sellToken: TokenAddress;
   buyToken: TokenAddress;
   order: Order;

--- a/src/services/quotes/quote-sources/wrappers/forced-timeout-wrapper.ts
+++ b/src/services/quotes/quote-sources/wrappers/forced-timeout-wrapper.ts
@@ -13,11 +13,13 @@ export function forcedTimeoutWrapper<
   return {
     getMetadata: () => source.getMetadata(),
     quote: ({ components, request, config }) => {
-      const description = `Quote ${request.sellToken} => ${request.buyToken} on ${request.chain.name} for source ${source.getMetadata().name}`;
+      const description = `Quote ${request.sellToken} => ${request.buyToken} on chain with id ${request.chainId} for source ${
+        source.getMetadata().name
+      }`;
       return timeoutPromise(source.quote({ components, request, config }), request.config.timeout, { description });
     },
     buildTx: ({ components, request, config }) => {
-      const description = `Tx build ${request.sellToken} => ${request.buyToken} on ${request.chain.name} for source ${
+      const description = `Tx build ${request.sellToken} => ${request.buyToken} on chain with id ${request.chainId} for source ${
         source.getMetadata().name
       }`;
       return timeoutPromise(source.buildTx({ components, request, config }), request.config.timeout, { description });

--- a/src/services/quotes/quote-sources/xy-finance-quote-source.ts
+++ b/src/services/quotes/quote-sources/xy-finance-quote-source.ts
@@ -42,7 +42,7 @@ export class XYFinanceQuoteSource extends AlwaysValidConfigAndContextSource<XYFi
   async quote({
     components: { fetchService },
     request: {
-      chain,
+      chainId,
       sellToken,
       buyToken,
       order,
@@ -52,10 +52,10 @@ export class XYFinanceQuoteSource extends AlwaysValidConfigAndContextSource<XYFi
     config,
   }: QuoteParams<XYFinanceSupport>): Promise<SourceQuoteResponse<XYFinanceData>> {
     const queryParams = {
-      srcChainId: chain.chainId,
+      srcChainId: chainId,
       srcQuoteTokenAddress: sellToken,
       srcQuoteTokenAmount: order.sellAmount.toString(),
-      dstChainId: chain.chainId,
+      dstChainId: chainId,
       dstQuoteTokenAddress: buyToken,
       slippage: slippagePercentage,
       receiver: recipient ?? takeFrom,
@@ -67,12 +67,12 @@ export class XYFinanceQuoteSource extends AlwaysValidConfigAndContextSource<XYFi
 
     const response = await fetchService.fetch(url, { timeout });
     if (!response.ok) {
-      failed(XY_FINANCE_METADATA, chain, sellToken, buyToken, await response.text());
+      failed(XY_FINANCE_METADATA, chainId, sellToken, buyToken, await response.text());
     }
     const { success, ...result } = await response.json();
     if (!success) {
       const { errorCode, errorMsg } = result;
-      failed(XY_FINANCE_METADATA, chain, sellToken, buyToken, `Failed with code ${errorCode} and message '${errorMsg}'`);
+      failed(XY_FINANCE_METADATA, chainId, sellToken, buyToken, `Failed with code ${errorCode} and message '${errorMsg}'`);
     }
 
     const {

--- a/src/services/quotes/source-lists/local-source-list.ts
+++ b/src/services/quotes/source-lists/local-source-list.ts
@@ -11,7 +11,6 @@ import {
   SourceQuoteResponse,
 } from '../quote-sources/types';
 import { timeoutPromise } from '@shared/timeouts';
-import { getChainByKeyOrFail } from '@chains';
 import { QUOTE_SOURCES, SourceConfig, SourceWithConfigId } from '../source-registry';
 import { buyToSellOrderWrapper } from '@services/quotes/quote-sources/wrappers/buy-to-sell-order-wrapper';
 import { forcedTimeoutWrapper } from '@services/quotes/quote-sources/wrappers/forced-timeout-wrapper';
@@ -162,7 +161,7 @@ function mapOrderToBigNumber(request: SourceListQuoteRequest): BuyOrder | SellOr
 
 function mapTxRequestToSourceRequest(response: QuoteResponseRelevantForTxBuild, timeout: TimeString | undefined): SourceQuoteBuildTxRequest {
   return {
-    chain: getChainByKeyOrFail(response.chainId),
+    chainId: response.chainId,
     sellToken: response.sellToken.address,
     buyToken: response.buyToken.address,
     type: response.type,
@@ -178,7 +177,7 @@ function mapTxRequestToSourceRequest(response: QuoteResponseRelevantForTxBuild, 
 
 function mapQuoteRequestToSourceRequest(request: SourceListQuoteRequest) {
   return {
-    chain: getChainByKeyOrFail(request.chainId),
+    chainId: request.chainId,
     sellToken: request.sellToken,
     buyToken: request.buyToken,
     order: mapOrderToBigNumber(request),

--- a/test/integration/services/quotes/sources/quote-sources.spec.ts
+++ b/test/integration/services/quotes/sources/quote-sources.spec.ts
@@ -48,7 +48,7 @@ import { wait } from '@shared/wait';
 
 // This is meant to be used for local testing. On the CI, we will do something different
 const RUN_FOR: { source: keyof typeof SOURCES_METADATA; chains: Chain[] | 'all' } = {
-  source: 'barter',
+  source: 'balancer',
   chains: [Chains.ETHEREUM],
 };
 const ROUNDING_ISSUES: SourceId[] = ['rango', 'wido'];
@@ -60,7 +60,7 @@ const AVOID_DURING_CI: SourceId[] = [
 jest.retryTimes(3);
 jest.setTimeout(ms('5m'));
 
-describe.skip('Quote Sources [External Quotes]', () => {
+describe('Quote Sources [External Quotes]', () => {
   const sourcesPerChain = getSources();
   for (const chainId of Object.keys(sourcesPerChain)) {
     const chain = getChainByKeyOrFail(chainId);
@@ -352,7 +352,7 @@ describe.skip('Quote Sources [External Quotes]', () => {
             order,
             sellToken: sellToken.address,
             buyToken: buyToken.address,
-            chain,
+            chainId: chain.chainId,
             config: {
               slippagePercentage: SLIPPAGE_PERCENTAGE,
               txValidFor: '5m',
@@ -370,7 +370,7 @@ describe.skip('Quote Sources [External Quotes]', () => {
           components: { providerService: PROVIDER_SERVICE, fetchService: FETCH_SERVICE },
           config: getConfig(sourceId),
           request: {
-            chain,
+            chainId: chain.chainId,
             sellToken: sellToken.address,
             buyToken: buyToken.address,
             ...quoteResponse,


### PR DESCRIPTION
We are no longer passing the `chain` object to quote sources. We will only be passing the chain id, so that other clients can integrate more easily 