### PR TITLE
fix: throw when forta attestation falis

### DIFF
--- a/src/services/earn/earn-service.ts
+++ b/src/services/earn/earn-service.ts
@@ -1025,6 +1025,9 @@ export class EarnService implements IEarnService {
       }),
       headers: { 'Content-Type': 'application/json' },
     });
+    if (!result.ok) {
+      throw new Error(`Failed to attest tx. Forta returned: ${await result.text()} (code: ${result.status})`);
+    }
     return result.json();
   }
 


### PR DESCRIPTION
We will now throw when the forta attestation fails. Before this change, we would continue with an invalid JSON, leading to other issues that were difficult to debug